### PR TITLE
Wrap pdf into a Boltzmann distribution

### DIFF
--- a/runners/rexfw/resaas/runners/rexfw/mpi.py
+++ b/runners/rexfw/resaas/runners/rexfw/mpi.py
@@ -7,34 +7,68 @@ from resaas.common.storage import SimulationStorage, load_storage_config
 
 from rexfw.communicators.mpi import MPICommunicator
 from rexfw.convenience import setup_default_re_master, setup_default_replica
+from rexfw.pdfs import AbstractPDF
 from rexfw.pdfs.normal import Normal
 from rexfw.samplers.rwmc import RWMCSampler
 from rexfw.slaves import Slave
 
 
-# TODO: put these classes some place where they belongs
-class AbstractPdf(ABC):
-    @abstractmethod
-    def log_prob(self, x):
-        pass
+class BoltzmannTemperedDistribution(AbstractPDF):
+    """
+    This wraps an object representing a probability density into a Boltzmann
+    ensemble.
 
-    @abstractmethod
-    def gradient(self, x):
-        pass
+    For a physical system with potential energy E, the configurational part
+    (meaning, independent from the momenta) of the Boltzmann distribution is
+    given by q(E|beta) \propto exp(-beta * E). Here, beta is, up to a constant,
+    the inverse temperature of the system of a heat bath the system is assumed
+    to be coupled to. For any probability distribution p(x), we can define a
+    pseudo-energy E(x) by E(x) = -log p(x). We can thus use the Boltzmann
+    distribution to modify the "ruggedness" (height of modes) of p(x) via beta:
+    for beta = 0; q(E(x)) becomes a uniform distribution, while for beta = 1,
+    q(E(x)) = p(x). Intermediate beta values can thus be used to create a
+    sequence of distributions that are increasingly easier to sample.
+    """
 
-
-class BoltzmannTemperedDistribution(AbstractPdf):
     def __init__(self, pdf, beta=1.0):
+        """
+        Initalizes a Boltzmann distribution for a fake physical system defined
+        by a probability density.
+
+        Args:
+            pdf(AbstractPdf): object representing a probability distribution
+            beta(float): inverse temperature in the range 0 < beta <= 1
+        """
         self.bare_pdf = pdf
         self.beta = beta
 
     def log_prob(self, x):
+        """
+        Log-probability of the Boltzmann distribution.
+
+        Args:
+            x: variate(s) of the underlying PDF
+        """
         return self.beta * self.bare_pdf.log_prob(x)
 
     def gradient(self, x):
+        """
+        Gradient of the Boltzmann distribution's log-probability.
+
+        Args:
+            x: variate(s) of the underlying PDF
+        """
         return self.beta * self.bare_pdf.gradient(x)
 
     def bare_log_prob(self, x):
+        """
+        Log-probability of the underlying probability density.
+
+        This is required for multiple histogram reweighting.
+
+        Args:
+            x: variate(s) of the underlying PDF
+        """
         return self.bare_pdf.log_prob(x)
 
 


### PR DESCRIPTION
Partially addresses #83. Related rexfw PR: https://github.com/tweag/rexfw/pull/8
This adds a Boltzmann distribution wrapper class to the MPI runner, which is required for rexfw to write out bare energies instead of log-probabilities, which include the inverse temperature.