### PR TITLE
Minor grpc call fixes

### DIFF
--- a/grpc/resaas/grpc/__init__.py
+++ b/grpc/resaas/grpc/__init__.py
@@ -1,7 +1,9 @@
-from resaas.grpc.health_checking_pb2 import (HealthCheckRequest,
-                                             HealthCheckResponse)
-from resaas.grpc.health_checking_pb2_grpc import (HealthServicer, HealthStub,
-                                                  add_HealthServicer_to_server)
+from resaas.grpc.health_checking_pb2 import HealthCheckRequest, HealthCheckResponse
+from resaas.grpc.health_checking_pb2_grpc import (
+    HealthServicer,
+    HealthStub,
+    add_HealthServicer_to_server,
+)
 
 
 class Health(HealthServicer):
@@ -9,6 +11,6 @@ class Health(HealthServicer):
         super(Health, self).__init__()
         self.callback = callback
 
-    def Check(self, request):
+    def Check(self, request, context):
         status = self.callback()
         return HealthCheckResponse(status=status)

--- a/scheduler/resaas/scheduler/jobs.py
+++ b/scheduler/resaas/scheduler/jobs.py
@@ -6,7 +6,7 @@ from typing import Callable, Dict, List, Optional
 import grpc
 import shortuuid
 from resaas.common.spec import JobSpec, JobSpecSchema
-from resaas.grpc import HealthCheckRequest, HealthStub
+from resaas.grpc import HealthCheckRequest, HealthCheckResponse, HealthStub
 from resaas.scheduler.config import SchedulerConfig
 from resaas.scheduler.db import TblJobs, TblNodes
 from resaas.scheduler.errors import JobError
@@ -212,11 +212,11 @@ class Job:
             stub = HealthStub(channel)
             while True:
                 response = stub.Check(HealthCheckRequest(service=""))
-                if response.status != "SERVING":
+                if response.status != HealthCheckResponse.SERVING:
                     break
                 else:
                     time.sleep(1)
-        if response.status == "SUCCESS":
+        if response.status == HealthCheckResponse.SUCCESS:
             return True
         else:
             return False


### PR DESCRIPTION
The `resaas.grpc.Health` wrapper was missing the context positional argument, and the `scheduler.job.Job.watch()` logic needed a small tweak to the values it was comparing. This also includes some auto-formatting changes from running black + isort and fixes a small issue in the constructor of `CloudREJobController`.