### PR TITLE
Add support for logging to Graphite events

### DIFF
--- a/app/controller/resaas/controller/run.py
+++ b/app/controller/resaas/controller/run.py
@@ -1,28 +1,33 @@
 """
 Main entrypoint to the resaas controller
 """
+import json
 import logging
 from concurrent import futures
 from dataclasses import dataclass
+from datetime import datetime
 from functools import partial
 from importlib import import_module
+from logging.handlers import MemoryHandler
+from math import floor
 from multiprocessing import Process
 from typing import Tuple
 
 import click
 import grpc
+import requests
 import yaml
 from marshmallow import Schema, fields
 from marshmallow.decorators import post_load
 from resaas.common.runners import AbstractRERunner, runner_config
 from resaas.common.spec import JobSpec, JobSpecSchema
 from resaas.common.storage import load_storage_config
-from resaas.grpc import Health, add_HealthServicer_to_server
 from resaas.controller import (
     CloudREJobController,
     optimization_objects_from_spec,
     update_nodes_mpi,
 )
+from resaas.grpc import Health, add_HealthServicer_to_server
 
 ProcessStatus = Tuple[bool, str]
 
@@ -46,6 +51,9 @@ class ControllerConfig:
     port: int = 50051
     n_threads: int = 10
     log_level: str = "INFO"
+    remote_logging: bool = True
+    remote_logging_port: int = 80
+    remote_logging_buffer_size: int = 5
 
 
 class ControllerConfigSchema(Schema):
@@ -58,10 +66,55 @@ class ControllerConfigSchema(Schema):
     port = fields.Integer()
     n_threads = fields.Integer()
     log_level = fields.String()
+    remote_logging = fields.Boolean()
+    remote_logging_port = fields.Integer()
+    remote_logging_buffer_size = fields.Integer()
 
     @post_load
     def make_controller_config(self, data, **kwargs) -> ControllerConfig:
         return ControllerConfig(**data)
+
+
+class GraphiteHTTPHandler(logging.Handler):
+    """A logging handler for writing Graphite events.
+
+    Uses `requests` internally and writes the log record to the Graphite event's
+    'data' field. Supports custom logging formaters.
+
+    Args:
+        url: The graphite events url
+        what: The name of the event
+        tags: An optional list of tags to give the event
+        timeout: Request timeout in seconds
+
+    """
+
+    def __init__(self, url: str, what="log", tags=None, timeout=5):
+        super().__init__()
+        self.url = url
+        self.timeout = timeout
+        self.what = what
+        if not tags:
+            self.tags = ["log"]
+        else:
+            self.tags = tags
+
+    def emit(self, record: logging.LogRecord):
+        try:
+            payload = {
+                "what": self.what,
+                "tags": self.tags + [record.levelname],
+                "when": floor(datetime.utcnow().timestamp()),
+                "data": self.format(record),
+            }
+            response = requests.post(
+                url=self.url,
+                data=json.dumps(payload),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception:
+            self.handleError(record)
 
 
 ##############################################################################
@@ -77,6 +130,7 @@ def load_runner(runner_path: str) -> AbstractRERunner:
             by a colon. e.g. 'some.module:MyRunner'
     """
     module, runner_name = runner_path.split(":")
+    logger.info(f"Attempting to load runner '{runner_name}' from {module}")
     module = import_module(module)
     return getattr(module, runner_name)
 
@@ -123,18 +177,37 @@ def run(job, config, storage, hostsfile, job_spec):
     with open(config) as f:
         config: ControllerConfig = ControllerConfigSchema().load(yaml.safe_load(f))
     # Configure logging
+    log_level = logging.getLevelName(config.log_level)
     base_logger = logging.getLogger("resaas")
-    base_logger.setLevel(logging.getLevelName(config.log_level))
+    base_logger.setLevel(log_level)
     basic_handler = logging.StreamHandler()
     basic_formatter = logging.Formatter("[%(levelname)s] %(asctime)s - %(name)s - %(message)s")
     basic_handler.setFormatter(basic_formatter)
     base_logger.addHandler(basic_handler)
 
-    # Load the job spec
+    if config.remote_logging:
+        logger.info("Configuring remote logging")
+
+        # Add graphite remote logging
+        graphite_handler = GraphiteHTTPHandler(
+            url=f"http://{config.metrics_address}:{config.remote_logging_port}/events",
+            what="log",
+            tags=["log"],
+        )
+        graphite_handler.setFormatter(basic_formatter)
+        # Use buffering to avoid having to making excessive calls
+        buffered_graphite_handler = MemoryHandler(
+            config.remote_logging_buffer_size, target=graphite_handler
+        )
+        base_logger.addHandler(buffered_graphite_handler)
+
+    logger.info("Loading job spec from file")
     with open(job_spec) as f:
         job_spec: JobSpec = JobSpecSchema().loads(f.read())
-    # Get storage backend
+
+    logger.info("Loading storage config file")
     backend_config = load_storage_config(storage)
+    logger.info("Initializing storage backend using config")
     storage_backend = backend_config.get_storage_backend()
 
     # Load the controller
@@ -165,7 +238,15 @@ def run(job, config, storage, hostsfile, job_spec):
     )
 
     # Start controller in another process
-    controller_proc = Process(target=controller.run_job, daemon=True)
+    def wrapped_run_job():
+        try:
+            controller.run_job()
+        except Exception as e:
+            # Ensures that top-level errors in the controller get logged
+            logger.exception(e)
+            raise e
+
+    controller_proc = Process(target=wrapped_run_job, daemon=True)
     controller_proc.start()
 
     # Gets the status of the controller process

--- a/lib/runners/rexfw/resaas/runners/rexfw/mpi.py
+++ b/lib/runners/rexfw/resaas/runners/rexfw/mpi.py
@@ -9,10 +9,10 @@ import click
 import mpi4py.rc
 import numpy as np
 from mpi4py import MPI
-from resaas.common.storage import SimulationStorage, load_storage_config
-from resaas.common.tempered_distributions import BoltzmannTemperedDistribution
 from resaas.common.pdfs import AbstractPDF
 from resaas.common.samplers.rwmc import RWMCSampler
+from resaas.common.storage import SimulationStorage, load_storage_config
+from resaas.common.tempered_distributions import BoltzmannTemperedDistribution
 
 from rexfw.communicators.mpi import MPICommunicator
 from rexfw.convenience import setup_default_re_master, setup_default_replica
@@ -57,7 +57,7 @@ def import_from_user() -> Tuple[AbstractPDF, np.ndarray]:
     try:
         from probability import initial_states, pdf
     except ImportError as e:
-        logging.exception(
+        logger.exception(
             "Failed to import user-defined pdf and initial_states. Does "
             "the `probability` module exist on the PYTHONPATH? "
             f"PYTHONPATH={sys.path}"


### PR DESCRIPTION
Addresses #133 by adding support for publishing controller logs as Graphite events. Graphite is not an ideal solution for logging (compared to something like InfluxDB, for example), but this should get the job done for the time being.
