### PR TITLE
Add default value for simulationRun argument to Graphite stats URLs

### DIFF
--- a/app/client/utils/const.js
+++ b/app/client/utils/const.js
@@ -8,9 +8,9 @@ export const JOBS_LIST_URL = `${SCHEDULER_URL}/jobs`;
 
 // Graphite
 export const GRAPHITE_URL = process.env.GRAPHITE_URL || 'http://127.0.0.1:8080';
-export const GRAPHITE_NEGLOGP_URL = (jobId, simulationRun) =>
+export const GRAPHITE_NEGLOGP_URL = (jobId, simulationRun = '*') =>
   `${GRAPHITE_URL}/render?target=aggregate(job${jobId}.${simulationRun}.*.negative_log_prob,'sum')&format=json&from=-3hours&until=now`;
-export const GRAPHITE_ACCEPTANCE_RATE_URL = (jobId, simulationRun) =>
+export const GRAPHITE_ACCEPTANCE_RATE_URL = (jobId, simulationRun = '*') =>
   `${GRAPHITE_URL}/render?target=job${jobId}.${simulationRun}.replica*_replica*.acceptance_rate&format=json&from=-3hours&until=now`;
 export const GRAPHITE_LOGS_URL = (jobId) =>
   `${GRAPHITE_URL}/events/get_data?tags=log&tags=job${jobId}&from=-3hours&until=now`;

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
   client:
     image: "resaas-client:latest"
     volumes:
-      - /home/simeon/projects/resaas/app/client/next.config.js:/opt/app/next.config.js
+      - XXXXXXXXXXXXXXX:/opt/app/next.config.js
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Also replace explicit path by Xses in `docker-compose.yaml`.

The default argument to the Graphite stats URLs is needed after my recent refactoring. Otherwise the scheduler crashes.