### PR TITLE
Pin poetry version to a working one in MPI node Dockerfile

### DIFF
--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -34,7 +34,7 @@ FROM base as builder-common
 RUN apt-get update && apt-get install -y wget unzip git build-essential libffi-dev libssl-dev zlib1g-dev
 
 # Python package managers
-RUN pip install --upgrade pip && pip install "poetry~=1.1"
+RUN pip install --upgrade pip && pip install "poetry==1.1.5"
 
 ##############################################################################
 FROM builder-common as builder


### PR DESCRIPTION
Oh, well... we should nixify all these containes to avoid annoying things like that. It suddenly would build anymore, because the current poetry version being pulled in seems to be buggy.