### PR TITLE
Improve animation performances

### DIFF
--- a/app/client/components/AnimationMainPage.js
+++ b/app/client/components/AnimationMainPage.js
@@ -1,56 +1,53 @@
+import { useMemo, useCallback } from 'react';
 import { useSpring, animated } from 'react-spring';
 
+const xmin = -5;
+const xmax = 5;
+const eps = 0.3;
+const N = 3000;
+
 function ReactSpring({ duration }) {
-  const innerWidth = window.innerWidth;
-  const outerWidth = window.outerWidth;
-  const innerHeight = window.innerHeight;
-  const outerHeight = window.outerHeight;
+  let interpolate = useMemo(() => {
+    const { innerWidth, outerWidth, outerHeight } = window;
+    const n_hills = Math.floor(Math.random() * 3) + 1;
+    const n_hills_range = [...Array(n_hills).keys()];
+    const means = n_hills_range.map(() => Math.random() * (xmax / 2 - xmin / 2) + xmin / 2);
+    const sigmas = n_hills_range.map(() => Math.random() * 0.2 + 0.5);
+    const offset = (Math.random() + 0.2) / 1.2;
 
-  const xmin = -5;
-  const xmax = 5;
-  const n_hills = Math.floor(Math.random() * 3) + 1;
-  const n_hills_range = [...Array(n_hills).keys()];
-  const means = n_hills_range.map(() => Math.random() * (xmax / 2 - xmin / 2) + xmin / 2);
-  const sigmas = n_hills_range.map(() => Math.random() * 0.2 + 0.5);
-  const pathFunction = (x) => {
-    if (x >= xmin) {
-      let y_unnorm = n_hills_range
-        .map((i) => (1 / sigmas[i]) * Math.exp(-Math.pow((x - means[i]) / sigmas[i], 2) / 2))
-        .reduce((a, b) => a + b, 0);
-      return y_unnorm / n_hills;
-    } else {
-      return 0;
-    }
-  };
+    const pathFunction = (x) => {
+      if (x >= xmin) {
+        let y_unnorm = n_hills_range
+          .map((i) => (1 / sigmas[i]) * Math.exp(-Math.pow((x - means[i]) / sigmas[i], 2) / 2))
+          .reduce((a, b) => a + b, 0);
+        return y_unnorm / n_hills;
+      } else {
+        return 0;
+      }
+    };
 
-  const N = 3000;
-  const eps = 0.3;
-  const offset = (Math.random() + 0.2) / 1.2;
-  let globalPath = [...Array(Math.floor(N * (1 + eps))).keys()]
-    .map((i) => i - Math.floor(N * eps))
-    .map((i) => xmin + (xmax - xmin) * (i / N))
-    .map((x) => {
-      let y = pathFunction(x);
-      let x_norm = ((x - xmin) / (xmax - xmin)) * innerWidth;
-      let y_norm = -(y / (xmax - xmin)) * outerWidth + offset * outerHeight;
-      return `${x_norm} ${y_norm}`;
-    });
-  let interpolate = (t) => {
-    let path = globalPath.slice(Math.floor(t * N), Math.floor((t + eps) * N)).join(' L');
-    path = 'M' + path;
-    return path;
-  };
+    const globalPath = [...Array(Math.floor(N * (1 + eps))).keys()]
+      .map((i) => i - Math.floor(N * eps))
+      .map((i) => xmin + (xmax - xmin) * (i / N))
+      .map((x) => {
+        let y = pathFunction(x);
+        let x_norm = ((x - xmin) / (xmax - xmin)) * innerWidth;
+        let y_norm = -(y / (xmax - xmin)) * outerWidth + offset * outerHeight;
+        return `${x_norm} ${y_norm}`;
+      });
+    return (t) => {
+      let path = globalPath.slice(Math.floor(t * N), Math.floor((t + eps) * N)).join(' L');
+      if (path.length === 0) {
+        return 'M' + globalPath[globalPath.length - 1];
+      }
+      return 'M' + path;
+    };
+  }, []);
 
   const props = useSpring({ t: 1 + eps, from: { t: 0 }, config: { duration } });
+  const d = useMemo(() => props.t.interpolate(interpolate), [interpolate]);
 
-  return (
-    <animated.path
-      d={props.t.interpolate(interpolate)}
-      stroke="black"
-      fill="none"
-      stroke-width="5"
-    ></animated.path>
-  );
+  return <animated.path d={d} stroke="black" fill="none" strokeWidth="5"></animated.path>;
 }
 
 export default ReactSpring;

--- a/app/client/pages/index.js
+++ b/app/client/pages/index.js
@@ -1,7 +1,6 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
-
-import { Layout, Button, FlexCenter, FlexCol, Container, Navbar } from '../components';
+import { Button, Container, FlexCenter, FlexCol, Layout, Navbar } from '../components';
 import AnimationMainPage from '../components/AnimationMainPage';
 
 const Heading = () => (
@@ -79,18 +78,40 @@ const fireAnimation = () => {
   setTimeout(() => {
     const div_to_del = document.getElementById(id);
     if (div_to_del) {
+      ReactDOM.unmountComponentAtNode(div_to_del);
       div_to_del.remove();
     }
   }, 6000);
 };
 
 export default function Home({ isMobile }) {
+  // use `toggleAnim` to set whether the animation should be enabled or not
+  const [anim, setAnim] = useState(null);
+  const toggleAnim = useCallback(
+    (doAnim) => {
+      // should do anim, but it is not currently activated
+      if (doAnim && anim === null) {
+        console.log('Animation is now enabled');
+        const newAnim = setInterval(() => {
+          fireAnimation();
+        }, 3000);
+        setAnim(newAnim);
+      }
+      // should not do anim but is currently activated
+      if (!doAnim && anim !== null) {
+        console.log('Animation is now disabled');
+        clearInterval(anim);
+        setAnim(null);
+      }
+    },
+    [anim]
+  );
+
   useEffect(() => {
-    const anim = setInterval(() => {
-      fireAnimation();
-    }, 3000);
-    return () => clearInterval(anim);
-  }, []);
+    // disable animation on mobile screen
+    toggleAnim(!isMobile);
+    return () => toggleAnim(false);
+  }, [isMobile]);
   return (
     <Layout>
       <FlexCol


### PR DESCRIPTION
This PR improves performances on home page by
* disabling animation on mobile
* using react memo hook to prevent unnecessary computations