### PR TITLE
Nix flakes-based development shell.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1633422542,
+        "narHash": "sha256-JYz2PmVogNRO8DhcvXzL/QhZzboTspJz2YSRlnAj8aM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aff647e2704fa1223994604887bb78276dc57083",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-21.05",
+        "repo": "nixpkgs",
+        "rev": "aff647e2704fa1223994604887bb78276dc57083",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Chainsail";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs = {
+      type = "github";
+      owner = "NixOS";
+      repo = "nixpkgs";
+      ref = "nixos-21.05";
+      rev = "aff647e2704fa1223994604887bb78276dc57083";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        devShell = import ./shell.nix { inherit pkgs; };
+      }
+    );
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,7 @@
 { sources ? import ./sources.nix }:     # import the sources
 with
   { overlay = _: pkgs:
-      { niv = import sources.niv {};    # use the sources :)
+      { niv = (import sources.niv {}).niv;    # use the sources :)
       };
   };
 import sources.nixpkgs                  # and use them again!

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     (python38.withPackages (pp: with pp; [ black ]))
     poetry # version 1.1.10 (required) while pythonPackages38.poetry is lower
-    niv.niv
+    niv
     yarn
     nodejs
     docker-compose
@@ -16,4 +16,3 @@ pkgs.mkShell {
   # Can also make use of the `.overrideAttrs` medthod to prevent from overwriting it (See PR #310 for details)
   LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.file}/lib";
 }
-  


### PR DESCRIPTION
Not super useful PR (I did not intend to make one at first). I just came up with this while experimenting with nix flakes.  
 It just builds a development shell, the *flake* way. Use `nix develop` to launch it.  
(For a reason that I don't understand, I did not manage to import `nix/default.nix` to use the versions of `niv` and `nixpkgs` that are pinned in `nix/sources.json`. So I just manually declared the same `nixpkgs` revision as input to the flake.)