### PR TITLE
Wait 2 minutes before sampling starts

### DIFF
--- a/app/controller/chainsail/controller/__init__.py
+++ b/app/controller/chainsail/controller/__init__.py
@@ -535,6 +535,10 @@ class CloudREJobController(BaseREJobController):
         """
         iteration = storage.sim_path
         self._ask_scheduler_to_add_iteration(iteration)
+        # Dirty hack to give nodes time (two mintues) to finish installing packages, compile Stan models etc.
+        # The fact that the controller can just kick off sampling whenever it likes, irrespective of whether the
+        # user code containers are ready, is a bug and tracked in https://github.com/tweag/chainsail/issues/386.
+        time.sleep(120)
         super()._do_single_run(storage)
 
 


### PR DESCRIPTION
To give nodes time to install / compile packages, compile Stan models etc.
This is a bad and dirty hack to mitigate the catastrophic effects of #386.

Currently, this hack is deployed to production (if production is deployed).