### PR TITLE
Add .env.local file with Firebase client values

### DIFF
--- a/app/client/.env.local
+++ b/app/client/.env.local
@@ -1,0 +1,7 @@
+# Update these with your Firebase app's values and put them in .env.local file
+NEXT_PUBLIC_FIREBASE_PUBLIC_API_KEY="AIzaSyCUWeTjqPkoi_Mlzl_yfFAFm_Z14anocSc"
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="resaas-simeon-dev.firebaseapp.com"
+NEXT_PUBLIC_FIREBASE_PROJECT_ID="resaas-simeon-dev"
+NEXT_PUBLIC_FIREBASE_DATABASE_URL="resaas-simeon-dev.appspot.com"
+NEXT_PUBLIC_FIREBASE_MSG_SENDER_ID="164370646194"
+NEXT_PUBLIC_FIREBASE_APP_ID="1:164370646194:web:fd872d4868dc64c586f5ab"


### PR DESCRIPTION
We could also think about getting these values from the secret manager (although they are not secret secrets), but as a stopgap measure this should do.