### PR TITLE
Don't try to fire animation if parent is not there yet

### DIFF
--- a/app/client/pages/index.js
+++ b/app/client/pages/index.js
@@ -84,7 +84,7 @@ const fireAnimation = () => {
   console.log('Animation fired');
   const parent = document.getElementById('animation-main-page');
   if (!parent) {
-    return
+    return;
   }
   const id = Math.random(); //or some such identifier
   const div = document.createElement('div');


### PR DESCRIPTION
When you're running the client in a development setting (manually using `yarn run dev` or whatever it is), and you navigate from the homepage to any other page, you get an annoying popup informing you about a JavaScript error in `fireAnimation` in `index.js`. It is raised upon `parent.appendChild(div)`; `parent` seems to be `undefined`.

I don't really know JS, so this is probably a hack. But it works.

Closes #349.