### PR TITLE
Change some references to hyperlinks

### DIFF
--- a/lib/runners/README.md
+++ b/lib/runners/README.md
@@ -4,7 +4,7 @@ Runners are responsible for executing a single Replica Exchange simulation with 
 
 ## Interface
 
-Runners have a very simple interface defined in `/lib/common/chainsail/common/runners.py`.
-It consists of a method `run_sampling` that takes a `SimulationStorage` object defined in `/lib/common/chainsail/common/storage.py`.
+Runners have a very simple interface defined in [/lib/common/chainsail/common/runners.py](/lib/common/chainsail/common/runners.py).
+It consists of a method `run_sampling` that takes a `SimulationStorage` object defined in [/lib/common/chainsail/common/storage.py](/lib/common/chainsail/common/storage.py).
 `run_sampling` is called by the controller application (`/app/controller/`).
 All runner implementations consume configuration, initial Markov chain states, timesteps etc. and write sampling data exclusively via the storage backend provided to `run_sampling`.

--- a/lib/runners/rexfw/README.md
+++ b/lib/runners/rexfw/README.md
@@ -9,11 +9,11 @@ The fork / branch used by Chainsail can be found [here](https://github.com/tweag
 As all Python code in Chainsail the `rexfw` runner is packaged using Poetry.
 Python dependencies are thus listed in `pyproject.toml`.
 Note that this runner has a crucial system dependency, namely a working Message Passing Interface (MPI) implemenation.
-Chainsail itself uses OpenMPI (https://www.open-mpi.org/), but others might or might not work, too.
+Chainsail itself uses [OpenMPI](https://www.open-mpi.org/), but others might or might not work, too.
 
 ## Design
 
-The `rexfw` runner implements the minimal `AbstractRERunner` interface from `/common/lib/runners/` in `./chainsail/runners/rexfw/__init__.py`.
-This class runs a Python script `./chainsail/runners/rexfw/mpi.py` via `mpirun`, and the Python script (and the actual `rexfw` library) uses the `mpi4py` library to communicate between processes.
+The `rexfw` runner implements the minimal `AbstractRERunner` interface from [/lib/common/chainsail/common/runners.py](/lib/common/chainsail/common/runners.py) in [./chainsail/runners/rexfw/\_\_init\_\_.py](./chainsail/runners/rexfw/__init__.py).
+This class runs a Python script [./chainsail/runners/rexfw/mpi.py](./chainsail/runners/rexfw/mpi.py) via `mpirun`, and the Python script (and the actual `rexfw` library) uses the `mpi4py` library to communicate between processes.
 `rexfw` has a controller / worker architecture, in which one controller process distributes sampling / exchange / other tasks to one or several workers and thus orchestrates a Replica Exchange simulation.
 Thanks to the use of MPI, the `rexfw` runner can be used on single machines as well as on a computing cluster or, as done in Chainsail's current full deployment, on a cluster of Kybernetes pods.


### PR DESCRIPTION
Changed a couple of code references to hyperlinks.

It's slightly painful to do so (as you have to repeat the code URL as link text), but it seems worthwhile. I tried angle bracket links (e.g. `<./docs/deployment.md>`) but this style only seems to work with `http` and `mailto` links.

Also made OpenMPI a hyperlink.