### PR TITLE
Fix bug when providing results zip file

### DIFF
--- a/app/scheduler/chainsail/scheduler/tasks.py
+++ b/app/scheduler/chainsail/scheduler/tasks.py
@@ -144,7 +144,6 @@ def scale_job_task(job_id, n_replicas) -> bool:
 def get_results_signed_url(job_id):
     logger.info(f"Getting signed URL for results of job #{job_id}...", extra={"job_id": job_id})
     # FIXME: new implementation
-    s3_client, container = get_s3_client_and_container()
     job_blob_root = get_job_blob_root(job_id)
     signed_url = get_signed_url(
         f"{job_blob_root}/{RESULTS_ARCHIVE_FILENAME}",

--- a/app/scheduler/chainsail/scheduler/utils.py
+++ b/app/scheduler/chainsail/scheduler/utils.py
@@ -38,7 +38,7 @@ def get_storage_dirname():
 
 def get_job_blob_root(job_id):
     storage_dirname = get_storage_dirname()
-    return os.path.join(storage_dirname, str(job_id)) + "/"
+    return os.path.join(storage_dirname, str(job_id))
 
 
 def get_signed_url(blob_path, expiry_time, s3=None, container=None):


### PR DESCRIPTION
I swear I had fixed this already - anyways, this fixes a bug that leads to invalid GCS URIs, at least invalid for `boto3`. Also removes a line of unneeded code.