### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @tweag/Engineers
+*       @simeoncarstens @dorranh @steshaw


### PR DESCRIPTION
After a discussion on the Tweag slack, this (explicitly listing code owners) seems to be the most reasonable option for now. The Tweag engineering org didn't work as code owners (https://github.com/tweag/chainsail/pull/436#issuecomment-1449582526) and would be too broad anyways.