### PR TITLE
Add zlib to get chainsail-controller-local to work

### DIFF
--- a/app/controller/.gitignore
+++ b/app/controller/.gitignore
@@ -1,0 +1,2 @@
+/job.json
+/probability.py

--- a/shell.nix
+++ b/shell.nix
@@ -14,8 +14,11 @@ pkgs.mkShell {
     python38Packages.tkinter
     terraform
     yarn
+    zlib
   ];
+
   # Setting the LD_LIBRARY_PATH environment variable.
-  # Can also make use of the `.overrideAttrs` medthod to prevent from overwriting it (See PR #310 for details)
-  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.file}/lib";
+  # Can also make use of the `.overrideAttrs` method to prevent from overwriting it.
+  # See PR #310 for details: https://github.com/tweag/chainsail/pull/310.
+  LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.file}/lib:${pkgs.zlib}/lib";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,19 +1,19 @@
 { pkgs ? import ./nix { } }:
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    poetry # version 1.1.10 (required) while pythonPackages38.poetry is lower
-    yarn
-    nodejs
     docker-compose
-    openmpi
-    python38Packages.tkinter
-    ncurses
     file
     gnumake
-    terraform
+    kubectl
     kubernetes-helm
     minikube
-    kubectl
+    ncurses
+    nodejs
+    openmpi
+    poetry # version 1.1.10 (required) while pythonPackages38.poetry is lower
+    python38Packages.tkinter
+    terraform
+    yarn
   ];
   # Setting the LD_LIBRARY_PATH environment variable.
   # Can also make use of the `.overrideAttrs` medthod to prevent from overwriting it (See PR #310 for details)


### PR DESCRIPTION
Adds zlib to `LD_LIBRARY_PATH`. This is the minimal change required to have a working Nix shell that runs `chainsail-controller-local` with [this probability.py](https://gist.github.com/steshaw/aa49002a533159619c3223c2489189ad) that I have handy.

I will be stacking future PRs on top of this one (for further nixification using poetry2nix). This will be the base PR.