### PR TITLE
Add dev shell for the controller

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .#controller

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ app/client/app.yaml
 
 
 /result
+/.direnv/

--- a/app/controller/README.md
+++ b/app/controller/README.md
@@ -44,3 +44,64 @@ The controller can be used as a stand-alone app on a single machine. To that end
    ```
 
 , which will run the main optimization loop and a production run and write all results to the directory specified via the `--dirname` argument.
+
+
+## Development workflow
+
+This is the development workflow for working with the controller locally.
+
+1. Enter the dev shell:
+
+```bash
+nix develop .#controller
+```
+
+2. Edit `../../lib/runners/rexfw/pyproject.toml` to add dependencies necessary to run the `probability.py`. e.g.
+
+```toml
+chainsail-helpers = "*"
+scipy = "*"
+pymc = "*"
+```
+
+3. Update the `poetry.lock` for the controller to bring in the additional dependencies:
+
+```sh-session
+$ poetry lock --no-update
+```
+
+4. Exit and re-enter the controller dev shell
+
+```bash
+exit
+nix develop .#controller
+```
+
+5. You will find that you have a Python interpreter on your PATH with the necessary dependencies:
+
+```sh-session
+$ which python
+/nix/store/4834b5pqk6fsn1sjh1mrpwdln9jw5nrj-python3-3.10.9-env/bin/python
+```
+
+6. Then, assuming you have [chainsail-resources](https://github.com/tweag/chainsail-resources/) cloned at the same level as [chainsail](https://github.com/tweag/chainsail) and you have a job.json in the `./app/controller` directory such as  [job.json](https://gist.github.com/steshaw/10edb377b89a5c315d92c3c2e40454ea), you can run the following examples from `chainsail-resources`.
+
+```bash
+PYTHONPATH=../../../chainsail-resources/examples/mixture/ chainsail-controller-local --job-spec=job.json --dirname=/tmp/out
+```
+
+```bash
+PYTHONPATH=../../../chainsail-resources/examples/pymc-mixture/ chainsail-controller-local --job-spec=job.json --dirname=/tmp/out
+```
+
+```bash
+$ PYTHONPATH=../../../chainsail-resources/examples/soft-kmeans/ chainsail-controller-local --job-spec=job.json --dirname=/tmp/out
+```
+
+7. You can edit local source files and they will be reflected the next time you run `chainsail-controller-local`.
+
+### Direnv
+
+There is `direnv` support supplied by [`../../.envrc`](../../.envrc). So, instead of `nix develop .#controller`, you can also enter a controller dev shell using `direnv allow`.
+
+If you like to use VS Code, you can install [direnv-vscode](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv) to enable Python tooling. VSCode uses Pylance from Microsoft, powered by Pyright.

--- a/app/controller/pyproject.toml
+++ b/app/controller/pyproject.toml
@@ -10,7 +10,7 @@ chainsail-controller = 'chainsail.controller.run:run'
 chainsail-controller-local = 'chainsail.controller.run_local:run'
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.8,<3.11"
 numpy = "*"
 chainsail-common = { path = "../../lib/common", develop = true }
 chainsail-grpc = { path = "../../lib/grpc", develop = true }

--- a/flake.lock
+++ b/flake.lock
@@ -40,15 +40,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1677613856,
-        "narHash": "sha256-sto7m/eN0GrWysJmCw6Uho4QImycXeH5R/PZe1dysXc=",
-        "owner": "nix-community",
+        "lastModified": 1677134716,
+        "narHash": "sha256-7HCPUwwjqI5TLsCOmaa9bsde5p19X95DprqpZWVsG4E=",
+        "owner": "steshaw",
         "repo": "poetry2nix",
-        "rev": "45babaf3f04aa1d53fa90e7ab9404360f7621919",
+        "rev": "d34e93c4779fd010cfb6b0de299d1399edc5cd9d",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "steshaw",
+        "ref": "git-branch-dependency",
         "repo": "poetry2nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,51 +24,61 @@
         ourYarn = nodePkgs.yarn.override(_: {
           nodejs = ourNode;
         });
+        controllerOverrides = final: prev:
+          let
+            addNativeBuildInputs = drvName: inputs: {
+              "${drvName}" = prev.${drvName}.overridePythonAttrs (
+                old: {
+                  nativeBuildInputs =
+                    (old.nativeBuildInputs or [ ]) ++ inputs;
+                }
+              );
+            };
+          in
+          { }
+          // addNativeBuildInputs "mpi4py" [ final.cython ]
+          // addNativeBuildInputs "rexfw" [ final.poetry-core ]
+          // addNativeBuildInputs "chainsail-helpers" [ final.poetry-core ];
+
+        controllerOpts = {
+          projectDir = ./app/controller;
+          overrides = poetry2nixPkg.overrides.withDefaults(controllerOverrides);
+          preferWheels = true;
+        };
+        controller = poetry2nixPkg.mkPoetryApplication controllerOpts;
+        controllerEnv = poetry2nixPkg.mkPoetryEnv controllerOpts;
+
+        basePackages = [
+          pkgs.docker-compose
+          pkgs.file
+          pkgs.gnumake
+          pkgs.kubectl
+          pkgs.kubernetes-helm
+          pkgs.minikube
+          pkgs.ncurses
+          ourNode
+          pkgs.openmpi
+          pkgs.poetry
+          pkgs.python38Packages.tkinter
+          pkgs.terraform
+          ourYarn
+        ];
+
+        pythonDevShell = ps: pkgs.mkShell {
+          packages = ps ++ basePackages;
+        };
+        controllerDevShell = pythonDevShell [
+          controllerEnv
+          controller
+        ];
       in
       {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            docker-compose
-            file
-            gnumake
-            kubectl
-            kubernetes-helm
-            minikube
-            ncurses
-            ourNode
-            openmpi
-            poetry
-            python38Packages.tkinter
-            terraform
-            ourYarn
-            zlib
-          ];
-
-          # Setting the LD_LIBRARY_PATH environment variable.
-          # Can also make use of the `.overrideAttrs` method to prevent from overwriting it.
-          # See PR #310 for details: https://github.com/tweag/chainsail/pull/310.
-          LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.file}/lib:${pkgs.zlib}/lib";
+        devShells = {
+          controller = controllerDevShell;
+          default = pkgs.mkShell { packages = basePackages; };
         };
         packages = {
-          controller = poetry2nixPkg.mkPoetryApplication {
-            projectDir = ./app/controller;
-            overrides = poetry2nixPkg.overrides.withDefaults (
-              final: prev:
-                let
-                  addNativeBuildInputs = drvName: inputs: {
-                    "${drvName}" = prev.${drvName}.overridePythonAttrs (
-                      old: {
-                        nativeBuildInputs =
-                          (old.nativeBuildInputs or [ ]) ++ inputs;
-                      }
-                    );
-                  };
-                in
-                { }
-                // addNativeBuildInputs "mpi4py" [ final.cython ]
-                // addNativeBuildInputs "rexfw" [ final.poetry-core ]
-            );
-          };
+          inherit controller;
           scheduler = poetry2nixPkg.mkPoetryApplication {
             projectDir = ./app/scheduler;
             overrides = poetry2nixPkg.overrides.withDefaults (

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs.url = "nixpkgs/release-22.11";
     yarn-nixpkgs.url = "nixpkgs/21.11";
     poetry2nix = {
-      url = "github:nix-community/poetry2nix";
+      url = "github:steshaw/poetry2nix/git-branch-dependency";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";


### PR DESCRIPTION
The default dev shell still has the base packages (such as poetry, terraform, kubectl, etc) — those that were originally in the `shell.nix`. The controller dev shell has all the base packages along with the `mkPoetryEnv` for controller as well as controller itself (to bring in the `run_rexfw_mpi` script).

The kludge of setting `LD_LIBRARY_PATH` in the shell is no longer required.

## Developer workflow with the new dev shell

The workflow for working with the controller in local development mode goes something like this:

1. Enter the dev shell with `nix develop .#controller`
2. Edit `./lib/runners/rexfw/pyproject.toml` to add dependencies necessary to run the `probability.py`. e.g.

```toml
chainsail-helpers = "*"
scipy = "*"
pymc = "*"
```

3. Update the `poetry.lock` for the controller to bring in the additional dependencies:

```sh-session
$ cd ./app/controller
$ poetry lock --no-update
```

4. Exit and re-enter the controller dev shell
5. You should find that you have a Python interpreter on your PATH with the necessary dependencies (note the `-env`):

```sh-session
$ which python
/nix/store/4834b5pqk6fsn1sjh1mrpwdln9jw5nrj-python3-3.10.9-env/bin/python
```

6. Then, assuming you have [chainsail-resources](https://github.com/tweag/chainsail-resources/) cloned at the same level as [chainsail](https://github.com/tweag/chainsail) and you have a job.json in the `./app/controller` directory such as  [job.json](https://gist.github.com/steshaw/10edb377b89a5c315d92c3c2e40454ea), you can run the examples from `chainsail-resources` except for httpstan (httpstan needs an extra server running which I haven't been able to connect with the chainsail-controller-local as yet).

```sh-session
$ cd ./app./controller
$ PYTHONPATH=../../../chainsail-resources/examples/mixture/ chainsail-controller-local --job-spec=job.json --dirname=/tmp/out
```

```sh-session
$ PYTHONPATH=../../../chainsail-resources/examples/pymc-mixture/ chainsail-controller-local --job-spec=job.json --dirname=/tmp/out
```

```sh-session
$ PYTHONPATH=../../../chainsail-resources/examples/soft-kmeans/ chainsail-controller-local --job-spec=job.json --dirname=/tmp/out
```

7. You can edit local source files and they will be reflected the next time you run `chainsail-controller-local`.

This workflow is now documented [as part of the PR](https://github.com/tweag/chainsail/blob/31efc13759be5a11ba089ff96579fe7899943fc0/app/controller/README.md#development-workflow).

### Direnv

I added direnv support which means that you can use `direnv allow` to get a controller dev shell. This also allows VS Code Python tooling to work along with the [direnv-vscode](https://marketplace.visualstudio.com/items?itemName=mkhl.direnv). The VSCode Python extension is Pylance from Microsoft which is powered by Pyright.