### PR TITLE
Constrain Kubernetes Terraform provider

### DIFF
--- a/terraform/cluster/local/main.tf
+++ b/terraform/cluster/local/main.tf
@@ -6,6 +6,12 @@ terraform {
   backend "local" {
     path = "terraform.tfstate"
   }
+  required_providers {
+    kubernetes = {
+      version = ">= 2.16.1"
+      source = "hashicorp/kubernetes"
+    }
+  }
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
This fixes an error along the lines of "Waiting for default secret of "default/chainsail-scheduler" to appear" reported by @steshaw.

Draft for now, because I didn't actually test whether the rest of the deployment works. But this change is analogous to #390, so I guess it should be fine. Maybe @steshaw could test this?