### PR TITLE
Remove tkinter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,6 @@
           ourNode
           pkgs.openmpi
           pkgs.poetry
-          pkgs.python38Packages.tkinter
           pkgs.terraform
           ourYarn
         ];


### PR DESCRIPTION
I think I added this a long time ago for plotting examples, which have since been moved to chainsail-resources. Furthermore, this leads to rebuilds of Python 3.8.