### PR TITLE
Cleanup `export`s in `app/client/run_dev_client.sh`

### DIFF
--- a/app/client/run_dev_client.sh
+++ b/app/client/run_dev_client.sh
@@ -4,7 +4,6 @@ SCHEDULER_URL=$(minikube service scheduler --url)
 MCMC_STATS_SERVER_URL=$(minikube service mcmc-stats-server --url)
 GRAPHITE_URL=$(minikube service graphite --url | head -n1)
 
-export SCHEDULER_URL=$SCHEDULER_URL
-export GRAPHITE_URL=$GRAPHITE_URL
-export MCMC_STATS_URL=$MCMC_STATS_SERVER_URL
+export SCHEDULER_URL MCMC_STATS_SERVER_URL GRAPHITE_URL
+
 yarn run dev


### PR DESCRIPTION
Another option would be to go for:

```
export SCHEDULER_URL=$(minikube service scheduler --url)
export MCMC_STATS_SERVER_URL=$(minikube service mcmc-stats-server --url)
export GRAPHITE_URL=$(minikube service graphite --url | head -n1)
```

This gives less duplication (and therefore less chances to update one part without updating the other) but it has a slightly different semantics because the variables are made accessible to the subsequent lines.