### PR TITLE
Bump `poetry` version to `1.3.0`

### DIFF
--- a/docker/mcmc-stats-server/Dockerfile
+++ b/docker/mcmc-stats-server/Dockerfile
@@ -25,7 +25,7 @@ FROM base as builder-common
 RUN apt-get update && apt-get install -y wget unzip git build-essential libffi-dev libssl-dev zlib1g-dev
 
 # Python package managers
-RUN pip install --upgrade pip && pip install "poetry==1.1.10"
+RUN pip install --upgrade pip && pip install "poetry==1.3.0"
 
 ##############################################################################
 FROM builder-common as builder

--- a/docker/user-code/Dockerfile
+++ b/docker/user-code/Dockerfile
@@ -27,7 +27,7 @@ FROM base as builder-common
 RUN apt-get update && apt-get install -y wget unzip git build-essential libffi-dev libssl-dev zlib1g-dev
 
 # Python package managers
-RUN pip install --upgrade pip && pip install "poetry==1.1.10"
+RUN pip install --upgrade pip && pip install "poetry==1.3.0"
 
 ##############################################################################
 FROM builder-common as builder


### PR DESCRIPTION
The Nix environment already provides 1.3.0 and some of the `Dockerfile`s were already updated in 8a34cf1. This commit follows the change in two other `Dockerfile`s. Additionally, this seems to fix an error I was encountering when running `make images`. Without this PR, I am getting:

```
 => ERROR [builder 4/4] RUN cd /app/app/user_code_server &&     poetry config virtualenvs.in-projec  4.0s
------                                                                                                    
 > [builder 4/4] RUN cd /app/app/user_code_server &&     poetry config virtualenvs.in-project true &&     poetry run pip install --upgrade pip &&     poetry install --no-dev:                                      
#16 0.883 Creating virtualenv chainsail-user-code-service in /app/app/user_code_server/.venv              
#16 1.713 Requirement already satisfied: pip in ./.venv/lib/python3.8/site-packages (23.1.2)
#16 3.004 Installing dependencies from lock file
#16 3.721 
#16 3.721 Package operations: 21 installs, 0 updates, 0 removals
#16 3.721 
#16 3.723   • Installing pyparsing (3.0.9)
#16 3.943 
#16 3.943   AttributeError
#16 3.943 
#16 3.943   'HTTPResponse' object has no attribute 'strict'
#16 3.943 
#16 3.944   at /usr/local/lib/python3.8/site-packages/cachecontrol/serialize.py:54 in dumps
#16 3.951        50│                 ),
#16 3.951        51│                 u"status": response.status,
#16 3.951        52│                 u"version": response.version,
#16 3.951        53│                 u"reason": text_type(response.reason),
#16 3.951     →  54│                 u"strict": response.strict,
#16 3.951        55│                 u"decode_content": response.decode_content,
#16 3.951        56│             }
#16 3.951        57│         }
#16 3.951        58│ 
#16 3.951 
------
```

but with this PR things build fine. I would guess that some API somewhere changed and Poetry 1.1.10 does not know about the change but Poetry 1.3.0 does, but I don't have an exact explanation.