### PR TITLE
Add BridgeStan to user code Docker image

### DIFF
--- a/app/user_code_server/pyproject.toml
+++ b/app/user_code_server/pyproject.toml
@@ -9,6 +9,10 @@ packages = [ { include = 'chainsail' } ]
 chainsail-user-code-server = 'chainsail.user_code_server:run'
 
 [tool.poetry.dependencies]
+# Other Python applications / libraries in this project have Python 3.8 as a
+# minimal requirement, but here we need Python 3.9 because that's the lower Python
+# version bound for BridgeStan. Else Poetry would not be able to resolve dependencies
+# when installing BridgeStan.
 python = "^3.9"
 numpy = "*"
 chainsail-common = { path = "../../lib/common", develop = true }

--- a/app/user_code_server/pyproject.toml
+++ b/app/user_code_server/pyproject.toml
@@ -9,7 +9,7 @@ packages = [ { include = 'chainsail' } ]
 chainsail-user-code-server = 'chainsail.user_code_server:run'
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 numpy = "*"
 chainsail-common = { path = "../../lib/common", develop = true }
 chainsail-grpc = { path = "../../lib/grpc", develop = true }

--- a/docker/user-code/Dockerfile
+++ b/docker/user-code/Dockerfile
@@ -1,7 +1,7 @@
 ##############################################################################
 # BASE
 ##############################################################################
-FROM python:3.8.7-slim as base
+FROM python:3.10-slim as base
 
 # Set up required directories
 RUN mkdir -p /app/deps && mkdir -p /run/sshd

--- a/docker/user-code/Dockerfile
+++ b/docker/user-code/Dockerfile
@@ -49,11 +49,11 @@ RUN cd /app/app/user_code_server && \
 ARG BRIDGESTAN_PATH=/app/deps/bridgestan
 RUN git clone --recurse-submodules --shallow-submodules --branch v2.1.1 --single-branch https://github.com/roualdes/bridgestan.git $BRIDGESTAN_PATH
 RUN cd /app/app/user_code_server && poetry add $BRIDGESTAN_PATH/python/
-# TODO: BridgeStan downloads the Stan compiler upon the first model compilation
-# (see https://github.com/roualdes/bridgestan/blob/cdde53c47db8608c23a79633f3620661b14682b0/Makefile#L137),
-# but ideally we would like to not have to do this at runtime. But if you just download it beforehand
-# to $BRIDGESTAN/bin/stanc, model compilation fails with an error about ./bin/stanc not being found, stemming
-# from the stan_math library.
+## BridgeStan requires the Stan compiler. If not available, it gets automatically downloaded
+## when first compiling a model, but why do this at runtime if we can do it at image build time
+RUN mkdir $BRIDGESTAN_PATH/bin
+RUN wget -O $BRIDGESTAN_PATH/bin/stanc https://github.com/stan-dev/stanc3/releases/download/v2.32.1/linux-stanc
+RUN chmod 777 $BRIDGESTAN_PATH/bin/stanc
 
 ##############################################################################
 # FINAL

--- a/docker/user-code/Dockerfile
+++ b/docker/user-code/Dockerfile
@@ -42,6 +42,15 @@ RUN cd /app/app/user_code_server && \
     poetry run pip install --upgrade pip && \
     poetry install --no-dev
 
+# Install BridgeStan
+ARG BRIDGESTAN_PATH=/app/deps/bridgestan
+RUN git clone --recurse-submodules --shallow-submodules --branch v2.1.1 --single-branch https://github.com/roualdes/bridgestan.git $BRIDGESTAN_PATH
+RUN cd /app/app/user_code_server && poetry add $BRIDGESTAN_PATH/python/
+# TODO: BridgeStan downloads the Stan compiler upon the first model compilation
+# (see https://github.com/roualdes/bridgestan/blob/cdde53c47db8608c23a79633f3620661b14682b0/Makefile#L137),
+# but ideally we would like to not have to do this at runtime. But if you just download it beforehand
+# to $BRIDGESTAN/bin/stanc, model compilation fails with an error about ./bin/stanc not being found, stemming
+# from the stan_math library.
 
 ##############################################################################
 # FINAL
@@ -62,7 +71,7 @@ RUN chmod 555 /app/entrypoint.sh
 # Adding the app venv bin to the front of path so it is the default pip, etc.
 ENV PATH=/app/app/user_code_server/.venv/bin:$PATH
 RUN pip install scipy==1.9.1 numpy==1.23.2 pymc==4.1.7 requests==2.28.1 chainsail-helpers==0.1.4
-
+ENV BRIDGESTAN=/app/deps/bridgestan
 WORKDIR /probability
 
 ENV USER_CODE_SERVER_PORT=50052

--- a/docker/user-code/Dockerfile
+++ b/docker/user-code/Dockerfile
@@ -1,6 +1,9 @@
 ##############################################################################
 # BASE
 ##############################################################################
+
+# We use Python 3.10 (in contrast to Python 3.8 elsewhere in this project), because
+# BridgeStan needs at least Python 3.9.
 FROM python:3.10-slim as base
 
 # Set up required directories


### PR DESCRIPTION
This PR adds BridgeStan (https://github.com/roualdes/bridgestan) to the user code image. Together with a [PR adding a BridgeStan wrapper to the `chainsail-helpers` library](https://github.com/tweag/chainsail-resources/pull/21), this allows users to easily use BridgeStan instead of `httpstan` to sample from their Stan models for a ~1000x speedup :rocket: 

Closes #424 (although the `httpstan` wrapper is still available).