### PR TITLE
Use Firebase authentication conditionally

### DIFF
--- a/app/client/components/Auth.js
+++ b/app/client/components/Auth.js
@@ -5,36 +5,43 @@ import firebase from 'firebase/app';
 import 'firebase/auth';
 import LogRocket from 'logrocket';
 
+const { serverRuntimeConfig } = require('../next.config.js');
 const AuthContext = createContext({});
 
 export const AuthProvider = ({ children }) => {
   firebaseClient();
   const [user, setUser] = useState(null);
 
-  useEffect(() => {
-    return firebase.auth().onIdTokenChanged(async (user) => {
-      if (!user) {
-        setUser(null);
-        nookies.set(undefined, 'token', '', {});
-        return;
-      } else {
-        try {
-          LogRocket.identify(user.uid, {
-            email: user.email,
-            name: user.displayName,
-          });
-          console.log('Identified to LogRocket');
-        } catch (e) {
-          console.log('Identify failed on ' + JSON.stringify(user) + ', session is anonyme');
-          console.log(e);
+  if (serverRuntimeConfig.require_auth) {
+    useEffect(() => {
+      return firebase.auth().onIdTokenChanged(async (user) => {
+        if (!user) {
+          setUser(null);
+          nookies.set(undefined, 'token', '', {});
+          return;
+        } else {
+          try {
+            LogRocket.identify(user.uid, {
+              email: user.email,
+              name: user.displayName,
+            });
+            console.log('Identified to LogRocket');
+          } catch (e) {
+            console.log('Identify failed on ' + JSON.stringify(user) + ', session is anonyme');
+            console.log(e);
+          }
         }
-      }
 
-      const token = await user.getIdToken();
-      setUser(user);
-      nookies.set(undefined, 'token', token, {});
+        const token = await user.getIdToken();
+        setUser(user);
+        nookies.set(undefined, 'token', token, {});
+      });
+    }, []);
+  } else {
+    useEffect(() => {
+      setUser(null);
     });
-  }, []);
+  }
   return <AuthContext.Provider value={{ user }}>{children}</AuthContext.Provider>;
 };
 export const useAuth = () => useContext(AuthContext);


### PR DESCRIPTION
Actually, the "developer mode" without user authentication didn't work with a clean repo checkout due to a missing Firebase API key, which we of course don't want to have to define if we don't want authentication. This seems to fix it.

> [!WARNING]
:skull: As with all things frontend, I obviously have no idea what I'm doing here, but it seems to work :skull: 